### PR TITLE
Import Repository

### DIFF
--- a/src/main/java/Equipa2/Incremento2/repository/AvaliacaoRepository.java
+++ b/src/main/java/Equipa2/Incremento2/repository/AvaliacaoRepository.java
@@ -3,6 +3,7 @@ package Equipa2.Incremento2.repository;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import Equipa2.Incremento2.model.Avaliacao;
 @Repository

--- a/src/main/java/Equipa2/Incremento2/repository/PagamentoRepository.java
+++ b/src/main/java/Equipa2/Incremento2/repository/PagamentoRepository.java
@@ -3,6 +3,7 @@ package Equipa2.Incremento2.repository;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import Equipa2.Incremento2.model.Pagamento;
 @Repository

--- a/src/main/java/Equipa2/Incremento2/repository/ServicoRepository.java
+++ b/src/main/java/Equipa2/Incremento2/repository/ServicoRepository.java
@@ -3,6 +3,7 @@ package Equipa2.Incremento2.repository;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import Equipa2.Incremento2.model.Servico;
 @Repository

--- a/src/main/java/Equipa2/Incremento2/repository/SolicitacaoRepository.java
+++ b/src/main/java/Equipa2/Incremento2/repository/SolicitacaoRepository.java
@@ -3,6 +3,7 @@ package Equipa2.Incremento2.repository;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import Equipa2.Incremento2.model.Solicitacao;
 @Repository

--- a/src/main/java/Equipa2/Incremento2/repository/UtilizadorRepository.java
+++ b/src/main/java/Equipa2/Incremento2/repository/UtilizadorRepository.java
@@ -3,6 +3,7 @@ package Equipa2.Incremento2.repository;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import Equipa2.Incremento2.model.Utilizador;
 @Repository


### PR DESCRIPTION
# `@Repository`

Faltava o `import org.springframework.stereotype.Repository;`.

## O que é?

A anotação `@Repository`, que faz parte do pacote org.springframework.stereotype, é usada para marcar uma classe como um componente de acesso a dados (Data Access Object - DAO) no Spring Framework. Isto significa que a classe anotada com `@Repository` está destinada a lidar com a lógica de persistência, como interagir com a base de dados.

De forma simples, a anotação `@Repository` indica que uma classe é responsável por aceder a dados, normalmente de uma base de dados. É usada para marcar classes que contêm métodos que fazem operações de CRUD (Criar, Ler, Atualizar, Apagar).

- O Spring vê esta anotação e sabe que deve criar um bean para esta classe, ou seja, faz com que a classe fique disponível para ser usada em outras partes da aplicação.

- Quando ocorre um erro ao aceder à base de dados (por exemplo, uma SQLException), o Spring traduz o erro para uma exceção mais fácil de gerir (DataAccessException).

- Facilita a organização do código, indicando claramente que a classe faz parte da camada de acesso a dados.

## Exemplo Simples

```
import org.springframework.stereotype.Repository;

@Repository
public class ProdutoDAO {
    public void guardarProduto(Produto produto) {
        // Lógica para guardar o produto na base de dados
        System.out.println("Produto guardado na base de dados.");
    }
}
```

Neste exemplo, a classe **ProdutoDAO** (Data Access Object) é marcada como @Repository, indicando que a sua função é lidar com dados.